### PR TITLE
fixes down() method in migration

### DIFF
--- a/database/migrations/create_stored_events_table.php.stub
+++ b/database/migrations/create_stored_events_table.php.stub
@@ -18,6 +18,6 @@ class CreateStoredEventsTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('logged_events');
+        Schema::dropIfExists('stored_events');
     }
 }


### PR DESCRIPTION
This PR is a quick fix in `down()` method in the migration.